### PR TITLE
Allow a IDynamicFileInfoProvider to be able to provide LSP diagnostics

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -272,6 +272,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
         private static bool AnalysisEnabled(Document document)
         {
+            if (document.Services.GetService<DocumentPropertiesService>()?.DiagnosticsLspClientName != null)
+            {
+                // This is a generated Razor document, and they want diagnostics, so let's report it
+                return true;
+            }
+
             // change it to check active file (or visible files), not open files if active file tracking is enabled.
             // otherwise, use open file.
             return document.IsOpen() && document.SupportsDiagnostics();

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/LiveShareLanguageServerClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/LiveShareLanguageServerClient.cs
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         public Task<Connection> ActivateAsync(CancellationToken token)
         {
             var (clientStream, serverStream) = FullDuplexStream.CreatePair();
-            _ = new InProcLanguageServer(serverStream, serverStream, _languageServerProtocol, _workspace, _diagnosticService);
+            _ = new InProcLanguageServer(serverStream, serverStream, _languageServerProtocol, _workspace, _diagnosticService, clientName: null);
             return Task.FromResult(new Connection(clientStream, clientStream));
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/RazorLanguageClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/RazorLanguageClient.cs
@@ -29,13 +29,15 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Lsp
     /// </summary>
     [ContentType(ContentTypeNames.CSharpLspContentTypeName)]
     [ContentType(ContentTypeNames.VBLspContentTypeName)]
-    [ClientName("RazorCSharp")]
+    [ClientName(ClientName)]
     [Export(typeof(ILanguageClient))]
     class RazorLanguageClient : ILanguageClient
     {
         private readonly IDiagnosticService _diagnosticService;
         private readonly LanguageServerProtocol _languageServerProtocol;
         private readonly Workspace _workspace;
+
+        public const string ClientName = "RazorCSharp";
 
         /// <summary>
         /// Gets the name of the language client (displayed to the user).

--- a/src/VisualStudio/Core/Def/Implementation/LanguageClient/RazorLanguageServer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageClient/RazorLanguageServer.cs
@@ -4,11 +4,7 @@
 
 #nullable enable
 
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageServer;
@@ -19,7 +15,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor.Lsp
     class RazorLanguageServer : InProcLanguageServer
     {
         public RazorLanguageServer(Stream inputStream, Stream outputStream, LanguageServerProtocol protocol, Workspace workspace, IDiagnosticService diagnosticService)
-            : base(inputStream, outputStream, protocol, workspace, diagnosticService)
+            : base(inputStream, outputStream, protocol, workspace, diagnosticService, clientName: RazorLanguageClient.ClientName)
         {
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
@@ -2,10 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Windows;
@@ -90,7 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 return key;
             }
 
-            private bool CheckAggregateKey(AggregatedKey key, DiagnosticsUpdatedArgs args)
+            private bool CheckAggregateKey(AggregatedKey? key, DiagnosticsUpdatedArgs? args)
             {
                 if (key == null)
                 {
@@ -216,12 +219,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             {
                 private readonly LiveTableDataSource _source;
                 private readonly Workspace _workspace;
-                private readonly ProjectId _projectId;
-                private readonly DocumentId _documentId;
+                private readonly ProjectId? _projectId;
+                private readonly DocumentId? _documentId;
                 private readonly object _id;
                 private readonly string _buildTool;
 
-                public TableEntriesSource(LiveTableDataSource source, Workspace workspace, ProjectId projectId, DocumentId documentId, object id)
+                public TableEntriesSource(LiveTableDataSource source, Workspace workspace, ProjectId? projectId, DocumentId? documentId, object id)
                 {
                     _source = source;
                     _workspace = workspace;
@@ -234,7 +237,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 public override object Key => _id;
                 public override string BuildTool => _buildTool;
                 public override bool SupportSpanTracking => _documentId != null;
-                public override DocumentId TrackingDocumentId => _documentId;
+                public override DocumentId? TrackingDocumentId => _documentId;
 
                 public override ImmutableArray<DiagnosticTableItem> GetItems()
                 {
@@ -255,7 +258,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             private class TableEntriesSnapshot : AbstractTableEntriesSnapshot<DiagnosticTableItem>, IWpfTableEntriesSnapshot
             {
                 private readonly DiagnosticTableEntriesSource _source;
-                private FrameworkElement[] _descriptions;
+                private FrameworkElement[]? _descriptions;
 
                 public TableEntriesSnapshot(
                     DiagnosticTableEntriesSource source,
@@ -267,7 +270,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     _source = source;
                 }
 
-                public override bool TryGetValue(int index, string columnName, out object content)
+                public override bool TryGetValue(int index, string columnName, [NotNullWhen(returnValue: true)] out object? content)
                 {
                     // REVIEW: this method is too-chatty to make async, but otherwise, how one can implement it async?
                     //         also, what is cancellation mechanism?
@@ -425,7 +428,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     return !string.IsNullOrWhiteSpace(item.Description);
                 }
 
-                public bool TryCreateDetailsContent(int index, out FrameworkElement expandedContent)
+                public bool TryCreateDetailsContent(int index, [NotNullWhen(returnValue: true)] out FrameworkElement? expandedContent)
                 {
                     var item = GetItem(index)?.Data;
                     if (item == null)
@@ -438,7 +441,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     return true;
                 }
 
-                public bool TryCreateDetailsStringContent(int index, out string content)
+                public bool TryCreateDetailsStringContent(int index, [NotNullWhen(returnValue: true)] out string? content)
                 {
                     var item = GetItem(index)?.Data;
                     if (item == null)
@@ -454,7 +457,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     }
 
                     content = item.Description;
-                    return true;
+                    return content != null;
                 }
 
                 private static FrameworkElement GetDescriptionTextBlock(DiagnosticData item)
@@ -469,7 +472,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 }
 
                 private static FrameworkElement GetOrCreateTextBlock(
-                    ref FrameworkElement[] caches, int count, int index, DiagnosticData item, Func<DiagnosticData, FrameworkElement> elementCreator)
+                    [NotNull] ref FrameworkElement[]? caches, int count, int index, DiagnosticData item, Func<DiagnosticData, FrameworkElement> elementCreator)
                 {
                     if (caches == null)
                     {
@@ -485,7 +488,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 }
 
                 // unused ones                    
-                public bool TryCreateColumnContent(int index, string columnName, bool singleColumnView, out FrameworkElement content)
+                public bool TryCreateColumnContent(int index, string columnName, bool singleColumnView, [NotNullWhen(returnValue: true)] out FrameworkElement? content)
                 {
                     content = default;
                     return false;
@@ -497,20 +500,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     return false;
                 }
 
-                public bool TryCreateStringContent(int index, string columnName, bool truncatedText, bool singleColumnView, out string content)
+                public bool TryCreateStringContent(int index, string columnName, bool truncatedText, bool singleColumnView, [NotNullWhen(returnValue: true)] out string? content)
                 {
                     content = default;
                     return false;
                 }
 
-                public bool TryCreateToolTip(int index, string columnName, out object toolTip)
+                public bool TryCreateToolTip(int index, string columnName, [NotNullWhen(returnValue: true)] out object? toolTip)
                 {
                     toolTip = default;
                     return false;
                 }
 
                 // remove this once we moved to new drop
-                public bool TryCreateStringContent(int index, string columnName, bool singleColumnView, out string content)
+                public bool TryCreateStringContent(int index, string columnName, bool singleColumnView, [NotNullWhen(returnValue: true)] out string? content)
                 {
                     content = default;
                     return false;
@@ -531,7 +534,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     id = analyzer.Analyzer.ToString();
                 }
 
-                return $"Kind:{e.Workspace.Kind}, Analyzer:{id}, Update:{e.Kind}, {(object)e.DocumentId ?? e.ProjectId}, ({string.Join(Environment.NewLine, e.Diagnostics)})";
+                return $"Kind:{e.Workspace.Kind}, Analyzer:{id}, Update:{e.Kind}, {(object?)e.DocumentId ?? e.ProjectId}, ({string.Join(Environment.NewLine, e.Diagnostics)})";
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
@@ -16,6 +16,7 @@ using System.Windows.Controls;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Common;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Imaging.Interop;
@@ -185,6 +186,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 {
                     // guard us from wrong provider that gives null diagnostic
                     Debug.Assert(false, "Let's see who does this");
+                    return false;
+                }
+
+                // If this diagnostic is for LSP only, then we won't show it here
+                if (diagnostic.Properties.ContainsKey(nameof(DocumentPropertiesService.DiagnosticsLspClientName)))
+                {
                     return false;
                 }
 

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
@@ -13,6 +13,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -348,13 +349,28 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                                                 .WhereNotNull()
                                                 .ToReadOnlyCollection();
 
+            var additionalProperties = GetAdditionalProperties(document, diagnostic);
+
+            var documentPropertiesService = document.Services.GetService<DocumentPropertiesService>();
+            var diagnosticsLspClientName = documentPropertiesService?.DiagnosticsLspClientName;
+
+            if (diagnosticsLspClientName != null)
+            {
+                if (additionalProperties == null)
+                {
+                    additionalProperties = ImmutableDictionary.Create<string, string>();
+                }
+
+                additionalProperties = additionalProperties.Add(nameof(documentPropertiesService.DiagnosticsLspClientName), diagnosticsLspClientName);
+            }
+
             return Create(diagnostic,
                 project.Id,
                 project.Language,
                 project.Solution.Options,
                 location,
                 additionalLocations,
-                GetAdditionalProperties(document, diagnostic));
+                additionalProperties);
         }
 
         private static DiagnosticData Create(

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/DocumentPropertiesService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/DocumentPropertiesService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 namespace Microsoft.CodeAnalysis.Host
 {
     /// <summary>
@@ -16,5 +18,11 @@ namespace Microsoft.CodeAnalysis.Host
         /// but is not passed to the compiler when the containing project is built.
         /// </summary>
         public virtual bool DesignTimeOnly => false;
+
+        /// <summary>
+        /// The LSP client name that should get the diagnostics produced by this document; any other source
+        /// will not show these diagnostics. If null, the diagnostics do not have this special handling.
+        /// </summary>
+        public virtual string? DiagnosticsLspClientName => null;
     }
 }


### PR DESCRIPTION
ASP.NET Razor is prototyping a system where they can add files into our workspace via IDynamicFileInfoProvider and can then query our LSP server to get diagnostics about those files. They're normally closed files but we want them to get analyzed always if they want to query them via LSP, and we also don't want those diagnostics to end up in the error list since further processing needs to be done with them with LSP.

This implements a hook where Razor can specify that diagnostics produced for their documents are ingored by most of the system, but can still be queried through their special LSP server.