### PR TITLE
Add ExternalAccess.Razor shims for newly added DocumentPropertiesService APIs.

### DIFF
--- a/src/Tools/ExternalAccess/Razor/IRazorDocumentPropertiesService.cs
+++ b/src/Tools/ExternalAccess/Razor/IRazorDocumentPropertiesService.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
+{
+    internal interface IRazorDocumentPropertiesService
+    {
+        /// <summary>
+        /// True if the source code contained in the document is only used in design-time (e.g. for completion),
+        /// but is not passed to the compiler when the containing project is built.
+        /// </summary>
+        public bool DesignTimeOnly { get; }
+
+        /// <summary>
+        /// The LSP client name that should get the diagnostics produced by this document; any other source
+        /// will not show these diagnostics.  For example, razor uses this to exclude diagnostics from the error list
+        /// so that they can handle the final display.
+        /// If null, the diagnostics do not have this special handling.
+        /// </summary>
+        public string? DiagnosticsLspClientName { get; }
+    }
+}

--- a/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
+++ b/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
@@ -22,6 +22,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Razor.Workspaces" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.Editor.Razor" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Razor" Key="$(RazorKey)" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServerClient.Razor" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.Mac.LanguageServices.Razor" Key="$(RazorKey)" />
   </ItemGroup>
 

--- a/src/Tools/ExternalAccess/Razor/RazorDocumentPropertiesServiceWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorDocumentPropertiesServiceWrapper.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
+{
+    internal class RazorDocumentPropertiesServiceWrapper : DocumentPropertiesService
+    {
+        public RazorDocumentPropertiesServiceWrapper(IRazorDocumentPropertiesService razorDocumentPropertiesService)
+        {
+            if (razorDocumentPropertiesService is null)
+            {
+                throw new ArgumentNullException(nameof(razorDocumentPropertiesService));
+            }
+
+            DesignTimeOnly = razorDocumentPropertiesService.DesignTimeOnly;
+            DiagnosticsLspClientName = razorDocumentPropertiesService.DiagnosticsLspClientName;
+        }
+
+        /// <summary>
+        /// True if the source code contained in the document is only used in design-time (e.g. for completion),
+        /// but is not passed to the compiler when the containing project is built.
+        /// </summary>
+        public override bool DesignTimeOnly { get; }
+
+        /// <summary>
+        /// The LSP client name that should get the diagnostics produced by this document; any other source
+        /// will not show these diagnostics.  For example, razor uses this to exclude diagnostics from the error list
+        /// so that they can handle the final display.
+        /// If null, the diagnostics do not have this special handling.
+        /// </summary>
+        public override string? DiagnosticsLspClientName { get; }
+    }
+}

--- a/src/Tools/ExternalAccess/Razor/RazorDocumentServiceProviderWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorDocumentServiceProviderWrapper.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
 
         private RazorSpanMappingServiceWrapper? _spanMappingService;
         private RazorDocumentExcerptServiceWrapper? _excerptService;
+        private RazorDocumentPropertiesServiceWrapper? _documentPropertiesService;
 
         public RazorDocumentServiceProviderWrapper(IRazorDocumentServiceProvider innerDocumentServiceProvider)
         {
@@ -60,6 +61,31 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
                 }
 
                 return (TService)(object)_excerptService;
+            }
+
+            if (typeof(TService) == typeof(DocumentPropertiesService))
+            {
+                if (_documentPropertiesService == null)
+                {
+                    lock (_lock)
+                    {
+                        if (_documentPropertiesService == null)
+                        {
+                            var documentPropertiesService = _innerDocumentServiceProvider.GetService<IRazorDocumentPropertiesService>();
+
+                            if (documentPropertiesService != null)
+                            {
+                                _documentPropertiesService = new RazorDocumentPropertiesServiceWrapper(documentPropertiesService);
+                            }
+                            else
+                            {
+                                return this as TService;
+                            }
+                        }
+                    }
+                }
+
+                return (TService)(object)_documentPropertiesService;
             }
 
             return this as TService;


### PR DESCRIPTION
- This will ensure Razor doesn't need to rely on its IVTness from Roslyn so we don't block Roslyn's efforts to remove IVTs.