### PR TITLE
Update version and add release/dev-test-2 configuration

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,10 +5,10 @@
     Roslyn version
   -->
   <PropertyGroup>
-    <MajorVersion>5</MajorVersion>
-    <MinorVersion>0</MinorVersion>
+    <MajorVersion>4</MajorVersion>
+    <MinorVersion>13</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>2</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>1</PreReleaseVersionLabel>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <!--
       By default the assembly version in official builds is "$(MajorVersion).$(MinorVersion).0.0".

--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -204,5 +204,15 @@
       "insertionCreateDraftPR": false,
       "insertionTitlePrefix": "[dNext]"
     }
+  },
+  "release/dev-test-2": {
+    "nugetKind": [
+      "Shipping",
+      "NonShipping"
+    ],
+    "vsBranch": "main",
+    "vsMajorVersion": 17,
+    "insertionTitlePrefix": "[17.13.P1]",
+    "insertionCreateDraftPR": false
   }
 }


### PR DESCRIPTION
This PR updates the version numbers and adds configuration for the release/dev-test-2 release branch.

**Changes:**
- Updated eng/Versions.props with new version numbers
- Added/updated eng/config/PublishData.json with release branch configuration

**Release Branch:** release/dev-test-2
**VS Version:** 17.13.P1