### PR TITLE
Prevent diagnostic port inheritance by child processes

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/DotnetCliHelper.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/DotnetCliHelper.cs
@@ -111,6 +111,11 @@ internal sealed class DotnetCliHelper : ILspService
         startInfo.Environment.Remove("MSBUILD_EXE_PATH");
         startInfo.Environment.Remove("MSBuildExtensionsPath");
 
+        // Diagnostic ports are scoped to a single runtime. Inheriting a suspended startup port from a traced host process
+        // causes the CLI process to wait indefinitely for a resume command intended for its parent.
+        startInfo.Environment.Remove("DOTNET_DiagnosticPorts");
+        startInfo.Environment.Remove("DOTNET_DefaultDiagnosticPortSuspend");
+
         var process = Process.Start(startInfo);
         Contract.ThrowIfNull(process, $"Unable to start dotnet CLI at {_dotnetExecutablePath.Value} with arguments {arguments} in directory {workingDirectory}");
         if (!keepStandardInputOpen)

--- a/src/Workspaces/MSBuild/Core/MSBuild/BuildHostProcessManager.cs
+++ b/src/Workspaces/MSBuild/Core/MSBuild/BuildHostProcessManager.cs
@@ -333,6 +333,11 @@ internal sealed class BuildHostProcessManager : IAsyncDisposable
         // it might try to load targets that aren't appropriate for the build host.
         processStartInfo.Environment.Remove("MSBUILD_EXE_PATH");
 
+        // Diagnostic ports are scoped to a single runtime. Inheriting a suspended startup port from a traced host process
+        // causes the build host to wait indefinitely for a resume command intended for its parent.
+        processStartInfo.Environment.Remove("DOTNET_DiagnosticPorts");
+        processStartInfo.Environment.Remove("DOTNET_DefaultDiagnosticPortSuspend");
+
         processStartInfo.CreateNoWindow = true;
         processStartInfo.UseShellExecute = false;
         processStartInfo.RedirectStandardInput = true;


### PR DESCRIPTION
## Summary

When launching the language server under a profiler, these env vars got inherited and blocked dotnet child processes from running until a profiler is attached.   This isn't useful as the profiler is already attached to the parent process and cannot attach to the child ones - so these profiling env vars should not be inherited.