### PR TITLE
Annotate nullable workspace service factories

### DIFF
--- a/src/Workspaces/Core/Portable/PublicAPI.Shipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Shipped.txt
@@ -931,7 +931,7 @@ Microsoft.CodeAnalysis.Host.Mef.ExportWorkspaceServiceFactoryAttribute.ServiceTy
 Microsoft.CodeAnalysis.Host.Mef.ILanguageServiceFactory
 Microsoft.CodeAnalysis.Host.Mef.ILanguageServiceFactory.CreateLanguageService(Microsoft.CodeAnalysis.Host.HostLanguageServices languageServices) -> Microsoft.CodeAnalysis.Host.ILanguageService
 Microsoft.CodeAnalysis.Host.Mef.IWorkspaceServiceFactory
-Microsoft.CodeAnalysis.Host.Mef.IWorkspaceServiceFactory.CreateService(Microsoft.CodeAnalysis.Host.HostWorkspaceServices workspaceServices) -> Microsoft.CodeAnalysis.Host.IWorkspaceService
+Microsoft.CodeAnalysis.Host.Mef.IWorkspaceServiceFactory.CreateService(Microsoft.CodeAnalysis.Host.HostWorkspaceServices workspaceServices) -> Microsoft.CodeAnalysis.Host.IWorkspaceService?
 Microsoft.CodeAnalysis.Host.Mef.MefHostServices
 Microsoft.CodeAnalysis.Host.Mef.MefHostServices.MefHostServices(System.Composition.CompositionContext compositionContext) -> void
 Microsoft.CodeAnalysis.Host.Mef.ServiceLayer

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/IWorkspaceServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/IWorkspaceServiceFactory.cs
@@ -16,5 +16,5 @@ public interface IWorkspaceServiceFactory
     /// Returns <c>null</c> if the service is not applicable to the given workspace.
     /// </summary>
     /// <param name="workspaceServices">The <see cref="HostWorkspaceServices"/> that can be used to access other services.</param>
-    IWorkspaceService CreateService(HostWorkspaceServices workspaceServices);
+    IWorkspaceService? CreateService(HostWorkspaceServices workspaceServices);
 }

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/MefWorkspaceServicesTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/MefWorkspaceServicesTests.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests;
+
+[UseExportProvider]
+public sealed class MefWorkspaceServicesTests
+{
+    [Fact]
+    public void FactoryMayReturnNull()
+    {
+        using var workspace = new AdhocWorkspace(FeaturesTestCompositions.Features.GetHostServices());
+
+        Assert.Null(workspace.Services.GetService<IWorkspaceEventListenerService>());
+    }
+}

--- a/src/Workspaces/CoreTestUtilities/Fakes/MockWorkspaceEventListenerProvider.cs
+++ b/src/Workspaces/CoreTestUtilities/Fakes/MockWorkspaceEventListenerProvider.cs
@@ -19,6 +19,6 @@ internal sealed class MockWorkspaceEventListenerProvider() : IWorkspaceServiceFa
 {
     public IEnumerable<IEventListener>? EventListeners;
 
-    public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-        => EventListeners != null ? new DefaultWorkspaceEventListenerServiceFactory.Service(workspaceServices.Workspace, EventListeners) : null!;
+    public IWorkspaceService? CreateService(HostWorkspaceServices workspaceServices)
+        => EventListeners != null ? new DefaultWorkspaceEventListenerServiceFactory.Service(workspaceServices.Workspace, EventListeners) : null;
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/MefWorkspaceServices.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Workspace/Mef/MefWorkspaceServices.cs
@@ -13,7 +13,7 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Roslyn.Utilities;
 
-[assembly: DebuggerTypeProxy(typeof(MefWorkspaceServices.LazyServiceMetadataDebuggerProxy), Target = typeof(ImmutableArray<Lazy<IWorkspaceService, WorkspaceServiceMetadata>>))]
+[assembly: DebuggerTypeProxy(typeof(MefWorkspaceServices.LazyServiceMetadataDebuggerProxy), Target = typeof(ImmutableArray<Lazy<IWorkspaceService?, WorkspaceServiceMetadata>>))]
 
 namespace Microsoft.CodeAnalysis.Host.Mef;
 
@@ -21,11 +21,11 @@ internal sealed class MefWorkspaceServices : HostWorkspaceServices
 {
     private readonly Workspace _workspace;
 
-    private readonly ImmutableArray<(Lazy<IWorkspaceService, WorkspaceServiceMetadata> lazyService, bool usesFactory)> _services;
+    private readonly ImmutableArray<(Lazy<IWorkspaceService?, WorkspaceServiceMetadata> lazyService, bool usesFactory)> _services;
 
     // map of type name to workspace service
-    private ImmutableDictionary<Type, (Lazy<IWorkspaceService, WorkspaceServiceMetadata>? lazyService, bool usesFactory)> _serviceMap
-        = ImmutableDictionary<Type, (Lazy<IWorkspaceService, WorkspaceServiceMetadata>? lazyService, bool usesFactory)>.Empty;
+    private ImmutableDictionary<Type, (Lazy<IWorkspaceService?, WorkspaceServiceMetadata>? lazyService, bool usesFactory)> _serviceMap
+        = ImmutableDictionary<Type, (Lazy<IWorkspaceService?, WorkspaceServiceMetadata>? lazyService, bool usesFactory)>.Empty;
 
     private readonly object _gate = new();
     private readonly HashSet<IDisposable> _ownedDisposableServices = new(ReferenceEqualityComparer.Instance);
@@ -42,9 +42,9 @@ internal sealed class MefWorkspaceServices : HostWorkspaceServices
         _workspace = workspace;
 
         var services = host.GetExports<IWorkspaceService, WorkspaceServiceMetadata>()
-            .Select(lz => (lz, usesFactory: false));
+            .Select(lz => (lazyService: new Lazy<IWorkspaceService?, WorkspaceServiceMetadata>(() => lz.Value, lz.Metadata), usesFactory: false));
         var factories = host.GetExports<IWorkspaceServiceFactory, WorkspaceServiceMetadata>()
-            .Select(lz => (new Lazy<IWorkspaceService, WorkspaceServiceMetadata>(() => lz.Value.CreateService(this), lz.Metadata), usesFactory: true));
+            .Select(lz => (lazyService: new Lazy<IWorkspaceService?, WorkspaceServiceMetadata>(() => lz.Value.CreateService(this), lz.Metadata), usesFactory: true));
 
         _services = [.. services, .. factories];
     }
@@ -101,6 +101,7 @@ internal sealed class MefWorkspaceServices : HostWorkspaceServices
         base.Dispose();
     }
 
+    [return: MaybeNull]
     public override TWorkspaceService GetService<TWorkspaceService>()
     {
         if (TryGetService(typeof(TWorkspaceService), out var lazyService, out var usesFactory))
@@ -117,7 +118,12 @@ internal sealed class MefWorkspaceServices : HostWorkspaceServices
             //   lock-free fast path.
             var checkAddDisposable = usesFactory && !lazyService.IsValueCreated;
 
-            var serviceInstance = (TWorkspaceService)lazyService.Value;
+            var serviceInstance = lazyService.Value;
+            if (serviceInstance is null)
+            {
+                return default;
+            }
+
             if (checkAddDisposable && serviceInstance is IDisposable disposable)
             {
                 lock (_gate)
@@ -126,15 +132,15 @@ internal sealed class MefWorkspaceServices : HostWorkspaceServices
                 }
             }
 
-            return serviceInstance;
+            return (TWorkspaceService)serviceInstance;
         }
         else
         {
-            return default!;
+            return default;
         }
     }
 
-    private bool TryGetService(Type serviceType, [NotNullWhen(true)] out Lazy<IWorkspaceService, WorkspaceServiceMetadata>? lazyService, out bool usesFactory)
+    private bool TryGetService(Type serviceType, [NotNullWhen(true)] out Lazy<IWorkspaceService?, WorkspaceServiceMetadata>? lazyService, out bool usesFactory)
     {
         if (!_serviceMap.TryGetValue(serviceType, out var service))
         {
@@ -200,7 +206,7 @@ internal sealed class MefWorkspaceServices : HostWorkspaceServices
     internal bool TryGetLanguageServices(string languageName, [NotNullWhen(true)] out MefLanguageServices? languageServices)
         => _languageServicesMap.TryGetValue(languageName, out languageServices);
 
-    internal sealed class LazyServiceMetadataDebuggerProxy(ImmutableArray<Lazy<IWorkspaceService, WorkspaceServiceMetadata>> services)
+    internal sealed class LazyServiceMetadataDebuggerProxy(ImmutableArray<Lazy<IWorkspaceService?, WorkspaceServiceMetadata>> services)
     {
         public (string type, string layer)[] Metadata
             => [.. services.Select(s => (s.Metadata.ServiceType, s.Metadata.Layer))];


### PR DESCRIPTION
## Summary
- annotate `IWorkspaceServiceFactory.CreateService` to permit null as documented
- propagate nullable factory results through MEF workspace service resolution
- remove the test factory's null-forgiving workaround and cover null service resolution

## Validation
- built `Microsoft.CodeAnalysis.Workspaces.csproj` with no warnings
- ran `MefWorkspaceServicesTests` on .NET 10 and .NET Framework 4.7.2